### PR TITLE
Dependency updates and general house-keeping.

### DIFF
--- a/Base.xcodeproj/project.pbxproj
+++ b/Base.xcodeproj/project.pbxproj
@@ -460,6 +460,7 @@
 		B06A5D0C1E4386AC00DAFF6B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
@@ -486,6 +487,7 @@
 		B06A5D0D1E4386AC00DAFF6B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;

--- a/Base/Network.swift
+++ b/Base/Network.swift
@@ -35,7 +35,7 @@ public struct Network {
                     BaseLog.network.log(.error, "Unable to start reachability notifier: \(error)")
                 }
                 
-                Network.ReachabilityTester.isReachable = tester.isReachable
+                Network.ReachabilityTester.isReachable = tester.connection != .none
             } else {
                 Network.ReachabilityTester.isReachable = true
             }

--- a/Base/UIRequestBehavior.swift
+++ b/Base/UIRequestBehavior.swift
@@ -8,55 +8,34 @@
 
 import UIKit
 
-public final class BackgroundTaskBehavior: RequestBehavior {
-    
-    private let application = UIApplication.shared
-    
-    private var identifier: UIBackgroundTaskIdentifier?
-    
-    public func before(sending: URLRequest) {
-        identifier = application.beginBackgroundTask(expirationHandler: {
-            self.endBackgroundTask()
-        })
-    }
-    
-    public func after(completion: URLResponse?) {
-        endBackgroundTask()
-    }
-    
-    public func after(failure: Error?, retry: () -> Void) {
-        endBackgroundTask()
-    }
-    
-    private func endBackgroundTask() {
-        if let identifier = identifier {
-            application.endBackgroundTask(identifier)
-            self.identifier = nil
-        }
-    }
-}
+//
+// Sample BackgroundTaskBehavior
+//
 
-public final class NetworkActivityIndicatorBehavior: RequestBehavior {
-    
-    class ActivityIndicatorState {
-        var counter = 0 {
-            didSet {
-                UIApplication.shared.isNetworkActivityIndicatorVisible = self.counter == 0
-            }
-        }
-    }
-    
-    static let state = ActivityIndicatorState()
-    
-    public func before(sending: URLRequest) {
-        NetworkActivityIndicatorBehavior.state.counter += 1
-    }
-    
-    public func after(completion: URLResponse?) {
-        NetworkActivityIndicatorBehavior.state.counter -= 1
-    }
-    
-    public func after(failure: Error?, retry: () -> Void) {
-        NetworkActivityIndicatorBehavior.state.counter -= 1
-    }
-}
+//public final class BackgroundTaskBehavior: RequestBehavior {
+//    
+//    private let application = UIApplication.shared
+//    
+//    private var identifier: UIBackgroundTaskIdentifier?
+//    
+//    public func before(sending: URLRequest) {
+//        identifier = application.beginBackgroundTask(expirationHandler: {
+//            self.endBackgroundTask()
+//        })
+//    }
+//    
+//    public func after(completion: URLResponse?) {
+//        endBackgroundTask()
+//    }
+//    
+//    public func after(failure: Error?, retry: () -> Void) {
+//        endBackgroundTask()
+//    }
+//    
+//    private func endBackgroundTask() {
+//        if let identifier = identifier {
+//            application.endBackgroundTask(identifier)
+//            self.identifier = nil
+//        }
+//    }
+//}

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "niceagency/Log" ~> 3.0
-github "ashleymills/Reachability.swift" ~> 3.0
+github "niceagency/Log" ~> 3.1
+github "ashleymills/Reachability.swift" ~> 4.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "ashleymills/Reachability.swift" "v3.0"
-github "niceagency/Log" "3.0"
+github "niceagency/Log" "3.1"
+github "ashleymills/Reachability.swift" "v4.1.0"


### PR DESCRIPTION
Updating dependencies to allow for App Extension API compliance.

Marking BackgroundTaskBehavior as a sample reference - as it uses UIApplication.shared which is forbidden within app extensions.