### PR TITLE
Fix operator precedence issue with default headers

### DIFF
--- a/Base/WebService.swift
+++ b/Base/WebService.swift
@@ -276,7 +276,7 @@ internal extension URLRequest {
             httpBody = data?.encoded()
         }
         
-        let headers = resource.headerProvider?.headers() ?? [] + additionalHeaders
+        let headers = (resource.headerProvider?.headers() ?? []) + additionalHeaders
         
         for (header, value) in headers {
             addValue(value, forHTTPHeaderField: header)


### PR DESCRIPTION
This PR fixes an issue where if a default header provider is added to the webservice and a header provider is added at a resource, the invalid operator precedence means the default header is ignored.